### PR TITLE
Add help command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
+help: # preview Makefile commands
+	@awk 'BEGIN { FS = ":.*#"; print "Usage:  make <target>\n\nTargets:" } \
+/^[-_[:alpha:]]+:.?*#/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
 ## ---- Dependency commands ---- ##
 
-install: # install dependencies
+install: # install Python dependencies
 	pipenv install --dev
 	pipenv run pre-commit install
 
-update: install # update all Python dependencies
+update: install # update Python dependencies
 	pipenv clean
 	pipenv update --dev
 
@@ -17,32 +21,31 @@ test: # run tests and print a coverage report
 	pipenv run coverage run --source=lambdas -m pytest -vv
 	pipenv run coverage report -m
 
-coveralls: test
+coveralls: test # write coverage data to an LCOV report
 	pipenv run coverage lcov -o ./coverage/lcov.info
 
 ## ---- Code quality and safety commands ---- ##
 
-# linting commands
-lint: black mypy ruff safety 
+lint: black mypy ruff safety # run linters
 
-black:
+black: # run 'black' linter and print a preview of suggested changes
 	pipenv run black --check --diff .
 
-mypy:
+mypy: # run 'mypy' linter
 	pipenv run mypy .
 
-ruff:
+ruff: # run 'ruff' linter and print a preview of errors
 	pipenv run ruff check .
 
-safety:
+safety: # check for security vulnerabilities and verify Pipfile.lock is up-to-date
 	pipenv check
 	pipenv verify
 
-# apply changes to resolve any linting errors
-lint-apply: black-apply ruff-apply
+lint-apply: # apply changes with 'black' and resolve 'fixable errors' with 'ruff'
+	black-apply ruff-apply 
 
-black-apply: 
+black-apply: # apply changes with 'black'
 	pipenv run black .
 
-ruff-apply: 
+ruff-apply: # resolve 'fixable errors' with 'ruff'
 	pipenv run ruff check --fix .

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Description of the function/functions.
 
 ## Development
 
+- To preview a list of available Makefile commands: `make help`
 - To install with dev dependencies: `make install`
 - To update dependencies: `make update`
 - To run unit tests: `make test`


### PR DESCRIPTION
### Purpose and background context
It was decided that we include a 'help' command to the Makefile to give an overview of the available Makefile commands.

### How can a reviewer manually see the effects of these changes?
Run `make help`. You should see the following:

```
(python-lambda-template) jcuerdo@X4GPY162G1 python-lambda-template % make help
Usage:  make <target>

Targets:
  help            preview Makefile commands
  install         install Python dependencies
  update          update Python dependencies
  test            run tests and print a coverage report
  coveralls       write coverage data to an LCOV report
  lint            run linters
  black           run 'black' linter and print a preview of suggested changes
  mypy            run 'mypy' linter
  ruff            run 'ruff' linter and print a preview of errors
  safety          check for security vulnerabilities and verify Pipfile.lock is up-to-date
  lint-apply      apply changes with 'black' and resolve 'fixable errors' with 'ruff'
  black-apply     apply changes with 'black'
  ruff-apply      resolve 'fixable errors' with 'ruff'
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-894

### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [x] The commit message is clear and follows our guidelines (not just this PR message)
- [x] There are appropriate tests covering any new functionality
- [x] The provided documentation is sufficient for understanding any new functionality introduced
- [x] Any manual tests have been performed and verified
- [x] New dependencies are appropriate or there were no changes