### PR TITLE
IN-1735 - Introduce shared ECR workflows to template repositories

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -21,3 +21,6 @@ jobs:
       AWS_REGION: us-east-1
       GHA_ROLE: <REPOSITORY_NAME>-gha-dev # NOTE: required update from template values
       ECR: <REPOSITORY_NAME>-dev # NOTE: required update from template values
+      FUNCTION: <REPOSITORY_NAME>-dev # NOTE: required update from template values
+      # DOCKERFILE: # only if the name of the Dockerfile is not "Dockerfile"!
+      # PREBUILD: # only if there is some pre-build dependency

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,23 @@
+name: Dev Image Build and Deploy
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+
+  build-push:
+    name: Dev Build and Push
+    uses: mitlibraries/.github/.github/workflows/ecr-multi-arch-deploy-dev.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: us-east-1
+      GHA_ROLE: <REPOSITORY_NAME>-gha-dev # NOTE: required update from template values
+      ECR: <REPOSITORY_NAME>-dev # NOTE: required update from template values

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,22 @@
+name: Prod Image Promote
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+
+  promote:
+    name: Prod promote
+    uses: mitlibraries/.github/.github/workflows/ecr-multi-arch-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: us-east-1
+      GHA_ROLE_STAGE: <REPOSITORY_NAME>-gha-stage # NOTE: required update from template values
+      GHA_ROLE_PROD: <REPOSITORY_NAME>-gha-prod # NOTE: required update from template values
+      ECR_STAGE: <REPOSITORY_NAME>-stage # NOTE: required update from template values
+      ECR_PROD: <REPOSITORY_NAME>-prod # NOTE: required update from template values

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -20,3 +20,5 @@ jobs:
       GHA_ROLE_PROD: <REPOSITORY_NAME>-gha-prod # NOTE: required update from template values
       ECR_STAGE: <REPOSITORY_NAME>-stage # NOTE: required update from template values
       ECR_PROD: <REPOSITORY_NAME>-prod # NOTE: required update from template values
+      FUNCTION: <REPOSITORY_NAME>-dev # NOTE: required update from template values
+      # DEFAULT_BRANCH: # Only if the default branch is not "main"!

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,23 @@
+name: Stage Image Build and Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+
+  build-push:
+    name: Stage Build and Push
+    uses: mitlibraries/.github/.github/workflows/ecr-multi-arch-deploy-stage.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: us-east-1
+      GHA_ROLE: <REPOSITORY_NAME>-gha-stage # NOTE: required update from template values
+      ECR: <REPOSITORY_NAME>-stage # NOTE: required update from template values

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -21,3 +21,6 @@ jobs:
       AWS_REGION: us-east-1
       GHA_ROLE: <REPOSITORY_NAME>-gha-stage # NOTE: required update from template values
       ECR: <REPOSITORY_NAME>-stage # NOTE: required update from template values
+      FUNCTION: <REPOSITORY_NAME>-dev # NOTE: required update from template values
+      # DOCKERFILE: # only if the name of the Dockerfile is not "Dockerfile"!
+      # PREBUILD: # only if there is some pre-build dependency

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ dmypy.json
 tests/sam/env.json
 
 output/
+
+.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ dmypy.json
 .arch_tag
 .aws-sam/
 tests/sam/env.json
+
+output/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
 ECR_NAME_DEV:=<REPOSITORY_NAME>-dev # NOTE: required update from template values
 ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/<REPOSITORY_NAME>-dev # NOTE: required update from template values
-FUNCTION_DEV:=<REPOSITORY_NAME> # NOTE: required update from template values
+FUNCTION_DEV:=<REPOSITORY_NAME>-dev # NOTE: required update from template values
 
 CPU_ARCH ?= $(shell cat .aws-architecture 2>/dev/null || echo "linux/amd64")
 
@@ -110,16 +110,6 @@ dist-dev: check-arch # Build docker container (intended for developer-based manu
 		--tag $(ECR_NAME_DEV):$$ARCH_TAG \
 		.
 
-docker-clean: # Clean up Docker detritus
-	@ARCH_TAG=$$(cat .arch_tag); \
-	echo "Cleaning up Docker leftovers (containers, images, builders)"; \
-	docker rmi -f $(ECR_URL_DEV):$$ARCH_TAG; \
-	docker rmi -f $(ECR_URL_DEV):make-$$ARCH_TAG; \
-	docker rmi -f $(ECR_URL_DEV):make-$(shell git describe --always) || true; \
-	docker rmi -f $(ECR_NAME_DEV):$$ARCH_TAG || true; \
-	docker buildx rm $(ECR_NAME_DEV) || true
-	@rm -rf .arch_tag
-
 publish-dev: dist-dev # Build, tag and push (intended for developer-based manual publish)
 	@ARCH_TAG=$$(cat .arch_tag); \
 	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $(ECR_URL_DEV); \
@@ -131,3 +121,13 @@ publish-dev: dist-dev # Build, tag and push (intended for developer-based manual
 
 update-lambda-dev: # Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
 	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest
+
+docker-clean: # Clean up Docker detritus
+	@ARCH_TAG=$$(cat .arch_tag); \
+	echo "Cleaning up Docker leftovers (containers, images, builders)"; \
+	docker rmi -f $(ECR_URL_DEV):$$ARCH_TAG; \
+	docker rmi -f $(ECR_URL_DEV):make-$$ARCH_TAG; \
+	docker rmi -f $(ECR_URL_DEV):make-$(shell git describe --always) || true; \
+	docker rmi -f $(ECR_NAME_DEV):$$ARCH_TAG || true; \
+	docker buildx rm $(ECR_NAME_DEV) || true
+	@rm -rf .arch_tag

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
+ECR_NAME_DEV:=<REPOSITORY_NAME>-dev # NOTE: required update from template values
+ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/<REPOSITORY_NAME>-dev # NOTE: required update from template values
+FUNCTION_DEV:=<REPOSITORY_NAME> # NOTE: required update from template values
+
+CPU_ARCH ?= $(shell cat .aws-architecture 2>/dev/null || echo "linux/amd64")
+
 help: # Preview Makefile commands
 	@awk 'BEGIN { FS = ":.*#"; print "Usage:  make <target>\n\nTargets:" } \
 /^[-_[:alpha:]]+:.?*#/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 # ensure OS binaries aren't called if naming conflict with Make recipes
-.PHONY: help install venv update test coveralls lint lint-fix security sam-build sam-http-run sam-http-ping sam-invoke
+.PHONY: help install venv update test coveralls lint lint-fix security sam-build sam-http-run sam-http-ping sam-invoke check-arch dist-dev docker-clean publish-dev update-lambda-dev
 
 ##############################################
 # Python Environment and Dependency commands
@@ -77,3 +83,51 @@ sam-http-ping: # SAM: Send curl command to SAM HTTP server
 sam-invoke: # SAM: Invoke lambda directly
 	echo '{"msg":"in a bottle"}' \
 	| sam local invoke -e -
+
+###############################################
+# Docker image, ECR, and Lambda Management
+###############################################
+check-arch:
+	@ARCH_FILE=".aws-architecture"; \
+	if [[ "$(CPU_ARCH)" != "linux/amd64" && "$(CPU_ARCH)" != "linux/arm64" ]]; then \
+        echo "Invalid CPU_ARCH: $(CPU_ARCH)"; exit 1; \
+    fi; \
+	if [[ -f $$ARCH_FILE ]]; then \
+		echo "latest-$(shell echo $(CPU_ARCH) | cut -d'/' -f2)" > .arch_tag; \
+	else \
+		echo "latest" > .arch_tag; \
+	fi
+
+dist-dev: check-arch # Build docker container (intended for developer-based manual build)
+	@ARCH_TAG=$$(cat .arch_tag); \
+	docker buildx inspect $(ECR_NAME_DEV) >/dev/null 2>&1 || docker buildx create --name $(ECR_NAME_DEV) --use; \
+	docker buildx use $(ECR_NAME_DEV); \
+	docker buildx build --platform $(CPU_ARCH) \
+		--load \
+		--tag $(ECR_URL_DEV):$$ARCH_TAG \
+		--tag $(ECR_URL_DEV):make-$$ARCH_TAG \
+		--tag $(ECR_URL_DEV):make-$(shell git describe --always) \
+		--tag $(ECR_NAME_DEV):$$ARCH_TAG \
+		.
+
+docker-clean: # Clean up Docker detritus
+	@ARCH_TAG=$$(cat .arch_tag); \
+	echo "Cleaning up Docker leftovers (containers, images, builders)"; \
+	docker rmi -f $(ECR_URL_DEV):$$ARCH_TAG; \
+	docker rmi -f $(ECR_URL_DEV):make-$$ARCH_TAG; \
+	docker rmi -f $(ECR_URL_DEV):make-$(shell git describe --always) || true; \
+	docker rmi -f $(ECR_NAME_DEV):$$ARCH_TAG || true; \
+	docker buildx rm $(ECR_NAME_DEV) || true
+	@rm -rf .arch_tag
+
+publish-dev: dist-dev # Build, tag and push (intended for developer-based manual publish)
+	@ARCH_TAG=$$(cat .arch_tag); \
+	aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $(ECR_URL_DEV); \
+	docker push $(ECR_URL_DEV):$$ARCH_TAG; \
+	docker push $(ECR_URL_DEV):make-$$ARCH_TAG; \
+	docker push $(ECR_URL_DEV):make-$(shell git describe --always); \
+	echo "Cleaning up dangling Docker images..."; \
+	docker image prune -f --filter "dangling=true"
+
+update-lambda-dev: # Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A template repository for creating Python lambda functions.
 
 1. Rename "my_function" to the desired initial function name across the repo. (May be helpful to do a project-wide find-and-replace).
 2. Update Python version if needed.
-3. Install all dependencies with `make install`.
+3. Create virtual environment and install dependencies with `make install`.
 4. Add initial function description to README and update initial required ENV variable documentation as needed.
 5. Update license if needed (check app-specific dependencies for licensing terms).
 6. Check Github repository settings:
@@ -15,6 +15,7 @@ A template repository for creating Python lambda functions.
    - Send initial exceptions to Sentry project for dev, stage, and prod environments to create them.
    - Create an alert for the prod environment only, with notifications sent to the appropriate team(s).
    - If *not* using Sentry, delete Sentry configuration from my_function.py and test_my_function_.py, and remove sentry_sdk from project dependencies.
+8. Update placeholder `<REPOSITORY_NAME>` in `.github/workflows` YAML files and `Makefile`.
 
 # my_function
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A template repository for creating Python lambda functions.
    - Send initial exceptions to Sentry project for dev, stage, and prod environments to create them.
    - Create an alert for the prod environment only, with notifications sent to the appropriate team(s).
    - If *not* using Sentry, delete Sentry configuration from my_function.py and test_my_function_.py, and remove sentry_sdk from project dependencies.
-8. Update placeholder `<REPOSITORY_NAME>` in `.github/workflows` YAML files and `Makefile`.
+8. Update placeholder `<REPOSITORY_NAME>` in `.github/workflows` YAML files and `Makefile`.  Make sure to coordinate with InfraEng's work on the `mitlib-tf-workloads-ecr` repository as needed.
 
 # my_function
 


### PR DESCRIPTION
### Purpose and background context

**Why these changes are being introduced:**

Formerly, template repositories like this did not contain Makefile commands for building or pushing Docker images, nor did it contain Github action (GHA) workflows.  The decision was made to include them in the templates, building on some work to standardize them, and assume the (harmless) risk that developers may run commands that fail because ECR repositories do not yet exist.

**How this addresses that need:**
* Adds github workflows for building and pushing ECR images, and promotion in production
* Updates Makefile to include commands to build and push Docker images

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
YES
* New repositories created from these templates will have mostly functional Docker and ECR functionality baked in.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1735

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.
